### PR TITLE
patch to parse json strings properly.

### DIFF
--- a/custom_components/kafka_multiple_topics/__init__.py
+++ b/custom_components/kafka_multiple_topics/__init__.py
@@ -131,8 +131,18 @@ class KafkaManager:
             or not topic_entities_filter(state.entity_id)
         ):
             return None
+        
+        # Attempt to parse state.state as JSON
+        try:
+            parsed_state = json.loads(state.state)
+        except (json.JSONDecodeError, TypeError):
+            parsed_state = state.state  # leave as-is if not JSON  
 
-        return json.dumps(obj=state.as_dict(), default=self._encoder.encode).encode(
+        # Replace state in the dict with parsed object
+        state_dict = state.as_dict()
+        state_dict["state"] = parsed_state                  
+
+        return json.dumps(obj=state_dict, default=self._encoder.encode).encode(
             "utf-8"
         )
 


### PR DESCRIPTION
Example bad payload:
```
{
"entity_id": "input_text.field0",
"state": "{\"field1\":\"value1\",\"field2\":\"value2\",\"field3\":\"value3\",\"timestamp\":\"2025-08-11T07:03:37-0400\"}",
"last_updated": "2025-08-11T11:03:37.186742+00:00",
}
```

- This PR aims to parse the state attribute of the payload as a true json object.

Notes:
1. It only modifies the state field of the dictionary.
2. If state.state is plain text (not JSON), it leaves it unchanged.
3. All other fields (attributes, timestamps, etc.) remain untouched.
4. Downstream code that consumes state.as_dict() is still compatible.